### PR TITLE
Remove duplicate keepWhitespaces default option and re-organize

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,13 +77,13 @@ truncate.setup(options)
 
 ```js
 {
-  byWords: false,
   stripTags: false,
   ellipsis: '...',
   decodeEntities: false,
-  keepWhitespaces: false,
   excludes: '',
+  byWords: false,
   reserveLastWord: false,
+  trimTheOnlyWord: false,
   keepWhitespaces: false
 }
 ```


### PR DESCRIPTION
Useful package, thanks for creating it!

- Fixed "keepWhitespaces" being listed twice in the example default options.
- Added missing "trimTheOnlyWord" default option in example options.
- Re-organized example default options to match jsdoc order above.