### PR TITLE
Ensure that `truncate()` always returns a string as documented.

### DIFF
--- a/src/truncate.ts
+++ b/src/truncate.ts
@@ -96,20 +96,20 @@ const defaultOptions: IOptions = {
 // an special object to store user's default options, keep the defaultOptions clean
 let userDefaults: IOptions = defaultOptions
 
-export default function truncate(html: string | CheerioAPI, length?: number | IOptions,  truncateOptions?: IOptions) {
+export default function truncate(html: string | CheerioAPI, length?: number | IOptions,  truncateOptions?: IOptions): string {
   const options = sanitizeOptions(length, truncateOptions)
 
   if (!html ||
     isNaN(options.length) ||
     options.length < 1 ||
     options.length === Infinity) {
-    return html
+    return isCheerioInstance(html) ? html.html() ?? '' : html;
   }
 
   let $: CheerioAPI
 
   if (isCheerioInstance(html)) {
-    $ = html as CheerioAPI
+    $ = html
   } else {
     // Add a wrapper for text node without tag like:
     //   <p>Lorem ipsum <p>dolor sit => <div><p>Lorem ipsum <p>dolor sit</div>
@@ -167,7 +167,7 @@ export default function truncate(html: string | CheerioAPI, length?: number | IO
   }
 
   travelChildren($html)
-  return $html.html()
+  return $html.html() ?? ''
 }
 
 truncate.setup = function (options: IOptions) {

--- a/test/truncate.spec.ts
+++ b/test/truncate.spec.ts
@@ -16,9 +16,10 @@ describe('Truncate html', () => {
     })
 
     it('should NOT truncate a string if NO length provided $', () => {
-      const html = cheerio.load('string')
+      const html = 'string'
+      const $ = cheerio.load(html)
 
-      expect(truncate(html)).toBe(html)
+      expect(truncate($)).toBe('<html><head></head><body>string</body></html>')
     })
 
     it('should NOT truncate a string if length is less than or equal to zero', () => {
@@ -31,7 +32,7 @@ describe('Truncate html', () => {
       const html = 'string'
       const $ = cheerio.load(html)
 
-      expect(truncate($, 0)).toBe($)
+      expect(truncate($, 0)).toBe('<html><head></head><body>string</body></html>')
     })
   })
 


### PR DESCRIPTION
Fixes #44