### PR TITLE
Fix byWords with emojis

### DIFF
--- a/src/truncate.ts
+++ b/src/truncate.ts
@@ -181,9 +181,11 @@ function truncateText(text: string, options: ITruncateOptions, isLastNode?: bool
     text = text.replace(/\s+/g, ' ')
   }
   const byWords = options.byWords
-  const match = text.match(astralRange)
-  const astralSafeCharacterArray = match === null ? [] : match
-  const strLen = match === null ? 0 : astralSafeCharacterArray.length
+  const astralSafeCharacterArray = text.match(astralRange)
+  if (!astralSafeCharacterArray) {
+    return ''
+  }
+  const strLen = astralSafeCharacterArray.length
   let idx = 0
   let count = 0
   let prevIsBlank = byWords
@@ -214,13 +216,7 @@ function truncateText(text: string, options: ITruncateOptions, isLastNode?: bool
   if (options.limit) {
     return text
   }
-  let str: string
-  if (byWords) {
-    str = text.substring(0, idx)
-  } else {
-    // @ts-expect-error fix ts error caused by regex
-    str = astralSafeCharacterArray.length ? substr(astralSafeCharacterArray, idx, options) : ''
-  }
+  const str = byWords ? astralSafeCharacterArray.slice(0, idx).join('') : substr(astralSafeCharacterArray, idx,  options)
   if (str === text) {
     // if is lat node, no need of ellipsis, or add it
     return isLastNode ? text : text + options.ellipsis

--- a/test/truncate.spec.ts
+++ b/test/truncate.spec.ts
@@ -637,6 +637,20 @@ describe('Truncate html', () => {
   })
 
   describe('should correcty handle text with emoji characters', () => {
+    afterEach(function () {
+      truncate.setup({
+        byWords: false,
+        stripTags: false,
+        ellipsis: "...",
+        // @ts-expect-error only for test
+        length: null,
+        decodeEntities: false,
+        keepWhitespaces: false,
+        excludes: "",
+        reserveLastWord: false,
+      });
+    })
+
     it('emojis with character length more than 1', () => {
       const test = '💩💩💩💩💩'
       const expected = '💩💩💩...'
@@ -674,6 +688,14 @@ describe('Truncate html', () => {
 
       expect(truncate(test, 20)).toEqual(expected)
     })
+
+    it("emojis with byWords setting", () => {
+      truncate.setup({ byWords: true })
+      const test = 'Hello there,   👋 how are you??'
+      const expected = 'Hello there, 👋...'
+
+      expect(truncate(test, 3)).toEqual(expected)
+    });
   })
 
   describe('customNodeStrategy', () => {

--- a/test/truncate.spec.ts
+++ b/test/truncate.spec.ts
@@ -298,6 +298,12 @@ describe('Truncate html', () => {
       expect(truncate(html, 10, options)).toBe(expected)
     })
 
+    it('should work with no text', () => {
+      const test = '<p></p>'
+      const expected = ''
+      expect(truncate(test, 10, { stripTags: true })).toBe(expected)
+    })
+
     it('should remove all tags', () => {
       const html =
         '<p><img src="abc.png">This <hr>is a string</p><br> for test.'


### PR DESCRIPTION
Hi,

This PR fixes a bug occuring when "byWords" is used on strings containing emojis characters

other changes :
* add test to improve coverage
* early return to remove `@ts-expect-error`